### PR TITLE
#2 Implemented Reference

### DIFF
--- a/MCViewer.Api/MCViewerRequestContent.cs
+++ b/MCViewer.Api/MCViewerRequestContent.cs
@@ -18,5 +18,8 @@ namespace MCViewer.Api
 		/// </summary>
 		[JsonProperty("Features")]
 		public List<MCViewerEtimFeature> Features { get; set; }
+
+		[JsonProperty("Reference")]
+		public object Reference { get; set; }
 	}
 }

--- a/MCViewer.Demo/Program.cs
+++ b/MCViewer.Demo/Program.cs
@@ -37,8 +37,17 @@ namespace MCViewer.Demo
 							RangeUpperValue= null,
 							AlphaNumericValue= null
 						}
+					},
+					Reference = new
+					{
+						This = "can be any object",
+						You = "would like it to be.",
+						As = "long as it is json-seralizable.",
+						We = "recommend to store a token",
+						In = "here, either as string",
+						Or = "as object (this example is an object)",
+						Good = "luck!"
 					}
-					/* And more... */
 				}
 			};
 

--- a/MCViewer.JS.Demo/app.js
+++ b/MCViewer.JS.Demo/app.js
@@ -19,7 +19,17 @@ var postObj = ({
 				rangeUpperValue: null,
 				alphaNumericValue: null
 			}
-		]
+		],
+		Reference:
+		{
+			this: "can be any object",
+			you: "would like it to be.",
+			as: "long as it is json-seralizable.",
+			we: "recommend to store a token",
+			in: "here, either as string",
+			or: "as object (this example is an object)",
+			good: "luck!"
+		}
 	}
 });
 


### PR DESCRIPTION
This PR will show an example of how to use the "reference" property in the content object.
This reference object will be posted back to the HookUrl and can then be used to retrieve the source of the edit.

This needs to be intergrated after the bugfix for the MC-Viewer on 2BA.